### PR TITLE
Added default logging

### DIFF
--- a/src/Telligent.Rest.SDK/Api/RestHost.cs
+++ b/src/Telligent.Rest.SDK/Api/RestHost.cs
@@ -127,9 +127,9 @@ namespace Telligent.Evolution.Extensibility.Rest.Version1
         /// <param name="ex"></param>
         public virtual void LogError(string message, Exception ex)
         {
-            if (LogErr != null)
+            if (HandleError != null)
             {
-                this.LogErr(message, ex);
+                this.HandleError(this, message, ex);
             }
             else
             {   // Default logging to W3SVC file
@@ -147,10 +147,7 @@ namespace Telligent.Evolution.Extensibility.Rest.Version1
         }
 
         #endregion
-      
-        public Action<string, Exception> LogErr { private get; set; }
-
-		#region REST
+        #region REST
 
         /// <summary>
         /// REST GET Request(Async) for Xml
@@ -698,5 +695,12 @@ namespace Telligent.Evolution.Extensibility.Rest.Version1
         }
 
         #endregion
+
+        #region  Delegates
+
+        public Action<RestHost, string, Exception> HandleError { private get; set; }
+        
+        #endregion
+
     }
 }

--- a/src/Telligent.Rest.SDK/Api/RestHost.cs
+++ b/src/Telligent.Rest.SDK/Api/RestHost.cs
@@ -127,10 +127,29 @@ namespace Telligent.Evolution.Extensibility.Rest.Version1
         /// <param name="ex"></param>
         public virtual void LogError(string message, Exception ex)
         {
+            if (LogErr != null)
+            {
+                this.LogErr(message, ex);
+            }
+            else
+            {   // Default logging to W3SVC file
+                try
+                {
+                    HttpContext.Current.Response.AppendToLog(
+                        this.GetType().FullName + " " +
+                        message + "\n" + ex.ToString()
+                        );
+                }
+                catch
+                {
+                }
+            }
         }
 
         #endregion
       
+        public Action<string, Exception> LogErr { private get; set; }
+
 		#region REST
 
         /// <summary>


### PR DESCRIPTION
The file /Api/RestHost.cs has LogError() Method, which can be overriden; however,
the drived class /Api/Host.cs does not override it; nor, makes it possible for user
of the Host class to do any logging.
This update introduces a LogErr Deligate in the base class RestHost, which enables users of drived
classes to define their own logging mechanism.  Additionally, if no logging delegate is supplied, we will default the errors to IIS W3SVC log file so that integration issues can be identified easier.
